### PR TITLE
Access fixes

### DIFF
--- a/BrutalAPI/Classes/Tools/Misc.cs
+++ b/BrutalAPI/Classes/Tools/Misc.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace BrutalAPI
 {
-    public  class Misc
+    public class Misc
     {
         /// <summary>
         /// Be careful, if the ID is already in use, it will create the VSData but not add it to the Pool!

--- a/BrutalAPI/Classes/Tools/ModConfiguration.cs
+++ b/BrutalAPI/Classes/Tools/ModConfiguration.cs
@@ -5,16 +5,16 @@ using UnityEngine;
 
 namespace BrutalAPI
 {
-    class ModConfiguration
+    public class ModConfiguration
     {
-        static public IModInformation PrepareAndAddMyModInformation(string modID)
+        static public ModInfoData PrepareAndAddMyModInformation(string modID)
         {
             bool isDisabled = LoadedDBsHandler.ModdingDB.IsModDisabled(modID);
             ModInfoData modData = new ModInfoData(modID, !isDisabled);
             LoadedDBsHandler.ModdingDB.AddNewModInfoData(modData);
             return modData;
         }
-        static public IModInformation PrepareAndAddMyModInformation(string modID, string name, string description, string credits, Sprite icon = null, bool showIconOnMainMenu = false)
+        static public ModInfoData PrepareAndAddMyModInformation(string modID, string name, string description, string credits, Sprite icon = null, bool showIconOnMainMenu = false)
         {
             bool isDisabled = LoadedDBsHandler.ModdingDB.IsModDisabled(modID);
             ModInfoData modData = new ModInfoData(modID, !isDisabled);

--- a/BrutalAPI/Classes/Tools/OverworldZone.cs
+++ b/BrutalAPI/Classes/Tools/OverworldZone.cs
@@ -6,7 +6,7 @@ using UnityEngine.InputSystem.XR;
 
 namespace BrutalAPI
 {
-    class OverworldZone
+    public class OverworldZone
     {
         #region ZONE DBs
         /// <summary>


### PR DESCRIPTION
 * Fixed `ModConfiguration` being `internal` instead of `public`.
 * Fixed `OverworldZone` being `internal` instead of `public`.
 * `ModConfiguration.PrepareAndAddMyModInformation()` now returns `ModInfoData` instead of `IModInformation`.