### PR TITLE
Console update 2

### DIFF
--- a/BrutalAPI/Classes/Console/PerformDelegateAction.cs
+++ b/BrutalAPI/Classes/Console/PerformDelegateAction.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BrutalAPI
+{
+    public class PerformDelegateAction(Action<CombatStats> action) : CombatAction
+    {
+        public override IEnumerator Execute(CombatStats stats)
+        {
+            action?.Invoke(stats);
+            yield break;
+        }
+    }
+}


### PR DESCRIPTION
- `damage`, `heal`, `endcombat` and `genpigment` commands no longer use effects.
- Added `indirect` optional argument to `damage` and `heal` commands.
- `genpigment` command can now generate pigment that can't normally be produced.
- Added `refresh`, `consumepigment`, `changenextzoneboss`, `unlockcontent` and `lockcontent` commands.